### PR TITLE
fix: don’t throw an error if index already exists

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -89,7 +89,11 @@ export async function start(options: StartESOptions): Promise<void> {
       const error = getESError(result);
 
       if (error) {
-        throw new Error(`Failed to create index: ${error.reason}`);
+        if (error.type === 'resource_already_exists_exception') {
+          debug(`Index ${name} already exists.`);
+        } else {
+          throw new Error(`Failed to create index: ${error.reason}`);
+        }
       }
     })
   );
@@ -139,6 +143,7 @@ async function isExistingFile(filepath: string): Promise<boolean> {
 
 interface ESError {
   reason: string;
+  type: string;
 }
 
 function getESError(esResponse: Buffer): ESError | undefined {


### PR DESCRIPTION
If for any reason `stop` isn't successful, it's impossible to `start` again as it will throw an index already exists error. This simply ignore that one type of error and continues on as usual.